### PR TITLE
- Save and restore navigation bar appearance

### DIFF
--- a/OpenWeb-SampleApp/UI/NavigationController/SampleAppNavigationController.swift
+++ b/OpenWeb-SampleApp/UI/NavigationController/SampleAppNavigationController.swift
@@ -44,7 +44,7 @@ private extension SampleAppNavigationController {
 
         if #available(iOS 13.0, *) {
             let appearance = UINavigationBarAppearance()
-            appearance.configureWithOpaqueBackground()
+            appearance.configureWithTransparentBackground()
             appearance.backgroundColor = navigationBarBackgroundColor
             appearance.titleTextAttributes = navigationTitleTextAttributes
 


### PR DESCRIPTION
Navigation shadow line fix by saving and restoring navigation bar appearance
Added a transparent navigation bat to our sample app to mimic what happens in Yahoo finance app so that we always see the changes between sample app navigation bar to the SDK navigation bar and back again. 